### PR TITLE
chore: Use Hatch for dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Functionality is fairly minimal and example usage should be referenced through t
 
 The server administrator should use the appropriate administrator-only commands to configure how notifications get sent out.
 
-## Getting Started
+## Development
 
 Place your Discord bot token in .env:
 
@@ -22,3 +22,11 @@ Dependencies are managed with [Hatch](https://hatch.pypa.io/latest/):
 hatch env create
 hatch run dev
 ```
+
+Run [black](https://pypi.org/project/black/) and [isort](https://pycqa.github.io/isort/index.html) on your code:
+
+``` sh
+hatch run lint:black
+hatch run lint:isort
+```
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ hatch run dev
 Run [black](https://pypi.org/project/black/) and [isort](https://pycqa.github.io/isort/index.html) on your code:
 
 ``` sh
-hatch run lint:black .
-hatch run lint:isort .
+hatch run style:check
+hatch run style:format
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ hatch run dev
 Run [black](https://pypi.org/project/black/) and [isort](https://pycqa.github.io/isort/index.html) on your code:
 
 ``` sh
-hatch run lint:black
-hatch run lint:isort
+hatch run lint:black .
+hatch run lint:isort .
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
-This uses the [discord.py](https://discordpy.readthedocs.io/en/stable/) wrapper around the Discord API.
+# Pairbot
 
-```
-pip install discord
-pip install python-dotenv
-```
-
-Edit .env to add the keys read by `os.getenv` in the code.
-
-```
-nohup python bot.py &
-```
-
-The server administrator should use the appropriate administrator-only commands to configure how notifications get sent out.
+## About
 
 This bot allows users to use Discord application commands ("slash commands") to sign up for pair programming practice according to their preferred schedule. User schedules are stored locally in a sqlite database.
 
 Functionality is fairly minimal and example usage should be referenced through the code.
+
+The server administrator should use the appropriate administrator-only commands to configure how notifications get sent out.
+
+## Getting Started
+
+Place your Discord bot token in .env:
+
+``` sh
+BOT_TOKEN_DEV=...
+```
+
+Dependencies are managed with [Hatch](https://hatch.pypa.io/latest/):
+
+``` sh
+hatch env create
+hatch run dev
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,19 @@ profile = "black"
 dev = "python bot.py -d"
 prod = "python bot.py"
 
-[tool.hatch.envs.lint]
+[tool.hatch.envs.style]
 detached = true
 dependencies = [
   "black",
   "isort"
+]
+
+[tool.hatch.envs.style.scripts]
+check = [
+  "black --check --diff .",
+  "isort --check-only --diff .",
+]
+format = [
+  "isort .",
+  "black .",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,10 @@ profile = "black"
 [tool.hatch.envs.default.scripts]
 dev = "python bot.py -d"
 prod = "python bot.py"
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black",
+  "isort"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,22 @@
+[project]
+name = "pairbot"
+version = "0.0.1"
+readme = "README.md"
+dependencies = [
+  "discord",
+  "python-dotenv"
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 profile = "black"
+
+[tool.hatch.envs.default.scripts]
+dev = "python bot.py -d"
+prod = "python bot.py"


### PR DESCRIPTION
This PR sets up a local dev environment with [Hatch](https://hatch.pypa.io/latest/). I've tried pipenv and poetry and I don't like them.